### PR TITLE
Length of the AuditLog short comment can be set in settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ src/django_reversion.egg-info/
 docs/_build
 .coverage
 *.sqlite3
+*.swp
+.directory

--- a/src/reversion/config.py
+++ b/src/reversion/config.py
@@ -1,0 +1,4 @@
+from django.conf import settings
+
+
+AUDIT_LOG_SHORT_COMMENT_LENGTH = getattr(settings, 'AUDIT_LOG_SHORT_COMMENT_LENGTH', 130)

--- a/src/reversion/filters.py
+++ b/src/reversion/filters.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
 from django.contrib.contenttypes.models import ContentType
 
 try:
@@ -23,12 +22,13 @@ class VersionContextTypeFilter(DefaultFilter):
     ALL_SLUG = '__all__'
 
     def get_widget(self):
-        print 'ted'
         from reversion.models import AuditLog
+
         if self.widget:
             return self.widget
 
-        formfield = forms.ModelChoiceField(queryset=ContentType.objects.filter(pk__in=AuditLog.objects.all().values('versions__content_type')))
+        formfield = forms.ModelChoiceField(queryset=ContentType.objects.filter(
+            pk__in=AuditLog.objects.all().values('versions__content_type')))
         formfield.choices = list(formfield.choices)
         if not formfield.choices[0][0]:
             del formfield.choices[0]

--- a/src/reversion/models.py
+++ b/src/reversion/models.py
@@ -21,7 +21,7 @@ from django.template.defaultfilters import truncatechars
 from chamber.utils.datastructures import ChoicesNumEnum
 
 from reversion.filters import VersionIDFilter, VersionContextTypeFilter
-
+from reversion import config
 
 def safe_revert(versions):
     """
@@ -259,7 +259,7 @@ class AuditLog(models.Model):
     comment = models.TextField(verbose_name=_('comment'), blank=True, help_text=_('A text comment on this revision.'))
 
     def short_comment(self):
-        return truncatechars(self.comment, 50)
+        return truncatechars(self.comment, config.AUDIT_LOG_SHORT_COMMENT_LENGTH)
     short_comment.short_description = _('Comment')
     short_comment.filter_by = 'comment'
     short_comment.order_by = 'comment'


### PR DESCRIPTION
The short comment length was too small, therefore I introduced a configurable variable in setttings. Since it is an audit log, is should not be necessary to configure it that often.
